### PR TITLE
Remove out-of-place period/full stop

### DIFF
--- a/src/HL/View/Home.hs
+++ b/src/HL/View/Home.hs
@@ -51,7 +51,7 @@ header url =
         summation =
           span_ [class_ "summary"] "An advanced purely-functional programming language"
         tag =
-          span_ [class_ "tag"] "Declarative, statically typed code."
+          span_ [class_ "tag"] "Declarative, statically typed code"
         sample =
           div_ [class_ "code-sample",title_ "This example is contrived in order to demonstrate what Haskell looks like, including: (1) where syntax, (2) enumeration syntax, (3) pattern matching, (4) consing as an operator, (5) list comprehensions, (6) infix functions. Don't take it seriously as an efficient prime number generator."]
                (haskellPre codeSample)


### PR DESCRIPTION
All other blurbs have none; removed for consistency
